### PR TITLE
Fix CISO8601 wheel problem

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 100
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/stage3-py.sh
+++ b/stage3-py.sh
@@ -70,7 +70,8 @@ mamba install --no-banner -y \
       pythreejs \
       bqplot \
       jupyterlab_execute_time \
-      ipympl
+      ipympl \
+      ciso8601
 # These are the things that are not in conda.
 pip install --upgrade \
        nbconvert[webpdf] \


### PR DESCRIPTION
(also put 100-minute timeout on GHA job--typically it takes about 25 minutes)