### PR TITLE
DM-39558: Link to rsp.lsst.io

### DIFF
--- a/rsp_notice
+++ b/rsp_notice
@@ -2,7 +2,7 @@ Welcome to the Rubin Observatory Science Platform Notebook Aspect.
 
 Find useful documentation for the software and Notebook Aspect at:
         https://pipelines.lsst.io
-        https://nb.lsst.io
+        https://rsp.lsst.io
 
 The Rubin Observatory Science Pipelines environment is in:
 


### PR DESCRIPTION
Replace nb.lsst.io with rsp.lsst.io. I'm linking to the root of the RSP docs rather than the notebook aspect guide because I think it'd be easier for users to situate themselves if they need to reference API aspect docs or understand how the RSP works overall.