### PR TITLE
tickets/DM-50293: remove non-LSST kernels

### DIFF
--- a/scripts/cleanup-files
+++ b/scripts/cleanup-files
@@ -6,5 +6,14 @@ for f in passwd group shadow gshadow; do
     rm /etc/${f} /etc/${f}-
 done
 
+# Copy logos across
+JLV=/usr/local/share/jupyterlab/venv
+cp ${JLV}/share/jupyter/kernels/python3/logo* \
+     /usr/local/share/jupyter/kernels/lsst
+# Remove default kernels
+for d in ${JLV} /opt/lsst/software/stack/conda/envs/lsst-scipipe-10.0.0 ; do
+    rm -rf ${d}/share/jupyter/kernels/python3
+done
+
 rm -rf /tmp/* /tmp/.*  # Modern Unixes don't recursively remove ".."
 

--- a/scripts/install-rsp-user
+++ b/scripts/install-rsp-user
@@ -52,3 +52,14 @@ uv cache clean
 
 # Put the alias back.
 mv $profdir/mamba.sh.save $profdir/mamba.sh
+
+# Copy the Python icon pageantry to our new kernel dir
+mkdir -p /usr/local/share/jupyter/kernels/lsst
+cp /usr/local/share/jupyterlab/venv/share/jupyter/kernels/python3/logo* \
+   /usr/local/share/jupyter/kernels/lsst/
+
+# Remove the default "python3" kernels
+for d in /usr/local/share/jupyterlab/venv \
+	 /opt/lsst/software/stack/conda/envs/lsst-scipipe-10.0.0 ; do
+    rm -rf ${d}/share/jupyter/kernels/python3
+done

--- a/scripts/install-rsp-user
+++ b/scripts/install-rsp-user
@@ -52,14 +52,3 @@ uv cache clean
 
 # Put the alias back.
 mv $profdir/mamba.sh.save $profdir/mamba.sh
-
-# Copy the Python icon pageantry to our new kernel dir
-mkdir -p /usr/local/share/jupyter/kernels/lsst
-cp /usr/local/share/jupyterlab/venv/share/jupyter/kernels/python3/logo* \
-   /usr/local/share/jupyter/kernels/lsst/
-
-# Remove the default "python3" kernels
-for d in /usr/local/share/jupyterlab/venv \
-	 /opt/lsst/software/stack/conda/envs/lsst-scipipe-10.0.0 ; do
-    rm -rf ${d}/share/jupyter/kernels/python3
-done


### PR DESCRIPTION
Remove the Python 3 kernels installed by default in the UI venv and in rubin-env.