### PR TITLE
Adopt v4 of multiplatform-build-and-push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
 
   build:
     needs: determine_tags
-    uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v3
+    uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v4
     with:
       images: ${{ github.event.inputs.image }}
       additional-tags: ${{ needs.determine_tags.outputs.rest_tags }}


### PR DESCRIPTION
* Strips "latest" tags from platform-specific builds