### PR TITLE
rubin-env-rsp resolution accomodation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ COPY static/runtime/lsst_kernel.json \
      static/runtime/lsstlaunch.bash /usr/local/share/jupyterlab/
 
 COPY scripts/install-rsp-user /tmp/build
+COPY scripts/extract-rubin-env-rsp.py /tmp/build
 RUN ./install-rsp-user
 RUN mkdir -p /usr/local/etc/jupyter/labconfig
 COPY scripts/modify-settings.py /tmp/build

--- a/scripts/extract-rubin-env-rsp.py
+++ b/scripts/extract-rubin-env-rsp.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Extract package specifications from rubin-env-rsp and install each package
+individually.
+
+This is a workaround for the (we hope very rare) case of
+https://github.com/lsst-sqre/sciplat-lab/actions/runs/25985290708
+where conda failed to find a solution for the rubin-env-rsp metapackage,
+but a rerun specifying each package individually installed just fine.
+"""
+
+from pathlib import Path
+import subprocess
+from typing import Any
+import yaml
+
+def _main() -> None:
+    _fetch_repo()
+    obj=_ingest_yaml()
+    pkgs=_digest_yaml(obj)
+    _print_package_specs(pkgs)
+
+
+def _fetch_repo() -> None:
+    """
+    Download the repository.  This will need to change if we change
+    feedstock repositories.
+    """
+    subprocess.run(
+        [ "git",
+          "clone",
+          "https://github.com/conda-forge/rubinenv-feedstock"
+         ]
+    )
+    
+
+def _ingest_yaml() -> dict[str,Any]:
+    """
+    Read the recipe into a Python object.
+
+    As long as the recipe stays in recipe.yaml (it changed from meta.yaml
+    not that long ago), we're fine.
+    """
+    recipe = Path("rubinenv-feedstock") / "recipe" / "recipe.yaml"
+    return yaml.safe_load(recipe.read_text())
+
+
+def _digest_yaml(doc: dict[str,Any]) -> list[str]:
+    """
+    Extract ``rubin-env-rsp`` from the recipe and capture version constraints
+    for each package.
+    """
+    op = doc["outputs"]
+    rersp = [ x for x in op if x["package"]["name"] == "rubin-env-rsp" ][0]
+    run = rersp["requirements"]["run"]
+    packages = [ x for x in run if not x.startswith("$") ]
+    return [ _reduce_pkg(x) for x in packages ]
+
+
+def _reduce_pkg(in_spec: str) -> str:
+    """
+    Reformat package name and constraints for installation from the conda
+    CLI.
+    """
+    pl = in_spec.split()
+    if len(pl) < 2:
+        return f"'{pl[0]}'"
+    return f"'{pl[0]}{pl[1]}'"
+
+                 
+def _print_package_specs(pkgs: list[str]) -> None:
+    """
+    Emit the package specs to install in a form suitable for feeding to
+    ``conda install`` on the command-line.
+    """
+    print(' '.join(pkgs))  # noqa: T201
+
+    
+if __name__ == "__main__":
+    _main()

--- a/scripts/install-rsp-user
+++ b/scripts/install-rsp-user
@@ -33,72 +33,22 @@ source $stackdir/loadLSST.bash
 
 rubin_env_ver=$(conda list rubin-env$ --json | jq -r '.[0].version')
 
-# set +e
-# conda install -y --no-update-deps "rubin-env-rsp==${rubin_env_ver}"
-# rc=$?
-# set -e
-# if [ ${rc} -ne 0 ]; then
-#    echo "Conda installation with --no-update-deps failed; retrying without"
-#    conda install -y "rubin-env-rsp==${rubin_env_ver}"
-# fi
-
-# Installing the components manually so we can tweak the recipe more easily.
-
-conda install -y --no-update-deps \
-       'awkward>=2.8.10' \
-       'awkward-pandas>=2023.8.0' \
-       'bokeh>=3.8.1' \
-       'bqplot>=0.12.45' \
-       'ciso8601>=2.3.3' \
-       'cloudpickle>=3.1.2' \
-       'dask-core>=2025.11.0' \
-       'datashader>=0.18.2' \
-       'fastparquet>=2024.11.0' \
-       'ffmpeg>=7.1.1' \
-       'freetype-py>=2.5.1' \
-       'geoviews>=1.15.0' \
-       'gh>=2.83.1' \
-       'ginga>=5.4.01' \
-       'graphicsmagick>=1.3.45' \
-       'hdf5plugin>=5.1.01' \
-       'holoviews>=1.21.01' \
-       'httpx>=0.28.1' \
-       'hvplot>=0.12.2' \
-       'intake>=2.0.8' \
-       'intake-parquet>=0.3.0' \
-       'ipympl>=0.10.0' \
-       'jedi>=0.19.2' \
-       'jupyter>=1.1.1' \
-       'lsdb>=0.6.7' \
-       'lsst-efd-client>=0.12.0' \
-       'mermaid-py>=0.8.0' \
-       'mysqlclient>=2.2.7' \
-       'nbval>=0.11.0' \
-       'panel>=1.8.3' \
-       'papermill>=2.6.0' \
-       'paramnb>=2.0.4' \
-       'partd>=1.4.2' \
-       'plotly>=6.5.0' \
-       'pre-commit>=4.4.0' \
-       'pypandoc>=1.16.2' \
-       'pyshp>=3.0.2' \
-       'python-snappy>=0.7.3' \
-       'python-socketio>=5.14.3' \
-       'pyvo>=1.8' \
-       'regions>=0.11' \
-       'reproject>=0.19.0' \
-       'ripgrep>=15.1.0' \
-       'rubin-nights>=0.8.1' \
-       'rubin-scheduler>=3.20.1' \
-       'rubin-sim>=2.6.0' \
-       'rubin.citsci>=0.9.2' \
-       'sbpy>=0.5.0' \
-       'schedview>=0.20.0' \
-       'snappy>=1.2.2' \
-       'toolz>=1.1.0' \
-       'wget>=1.25.0' \
-       'xarray>=2025.11.0'
-
+set +e
+conda install -y --no-update-deps "rubin-env-rsp==${rubin_env_ver}"
+rc=$?
+set -e
+if [ ${rc} -ne 0 ]; then
+    echo "Conda installation of pinned-rubin-env rubin-env-rsp failed."
+    echo "Trying with allowing floating dependencies."
+    conda install -y "rubin-env-rsp==${rubin_env_ver}"
+    rc=$?
+fi
+set -e
+if [ ${rc} -ne 0 ]; then
+    echo "Conda installation of rubin-env-rsp failed."
+    echo "Trying individual packages."
+    conda install -y --no-update-deps $(python3 extract-rubin-env-rsp.py)
+fi
 
 # To make life easier at USDF we are adding three T&S packages
 # (ts-m1m3-utils, ts-salobj, and ts-utils) that are not available from

--- a/scripts/modify-settings.py
+++ b/scripts/modify-settings.py
@@ -3,7 +3,6 @@
 
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
 from typing import Any


### PR DESCRIPTION
We saw a very strange failure where we could not install the rubin-env-rsp metapackage, but installing each of its components, with the identical version constraints, succeeded.

To guard against that in future, if we fail to install the metapackage, we download the recipe, extract the components of rubin-env-rsp and their version constraints, and install all of those directly with `conda install`.