### PR TITLE
tickets/DM-55576: generate tree view of Python dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,9 @@ on:
       input:
         description: 'input image; you probably should change at most the tag'
         required: false
-        default: 'ghcr.io/lsst-sqre/nublado-jupyterlab-base:latest'
+        # FIXME: change it back to 'latest' after DP2 is out and we've
+        # cleaned everything up.
+        default: 'ghcr.io/lsst-sqre/nublado-jupyterlab-base:tickets-DM-55555'
 
 # We need actions/write if we want to do a GH App, and we need
 # packages/write to push to ghcr.io with GITHUB_TOKEN

--- a/scripts/generate-versions
+++ b/scripts/generate-versions
@@ -14,11 +14,13 @@ uv pip list | tee "sciplat-system-python"
 if (which npm); then
     npm list --global --long --json | tee "sciplat-node-modules"
 fi
+uv pip tree | tee "sciplat-system-python-tree"
 
 # Now JupyterLab python
 
 source /usr/local/share/jupyterlab/venv/bin/activate
 uv pip list | tee "sciplat-jupyterlab-python"
+uv pip tree | tee "sciplat-jupyterlab-python-tree"
 ((jupyter labextension list 2>&1) | tee "sciplat-lab-extensions") || /bin/true
 deactivate
 
@@ -27,4 +29,4 @@ SHELL=bash
 export SHELL
 source /opt/lsst/software/stack/loadLSST.bash
 conda env export | tee sciplat-conda-stack.yaml
-
+conda-tree deptree --full | tee "sciplat-conda-stack-tree"

--- a/scripts/generate-versions
+++ b/scripts/generate-versions
@@ -29,4 +29,4 @@ SHELL=bash
 export SHELL
 source /opt/lsst/software/stack/loadLSST.bash
 conda env export | tee sciplat-conda-stack.yaml
-conda-tree deptree --full | tee "sciplat-conda-stack-tree"
+uv pip tree | tee "sciplat-conda-stack-tree"

--- a/scripts/generate-versions
+++ b/scripts/generate-versions
@@ -29,4 +29,8 @@ SHELL=bash
 export SHELL
 source /opt/lsst/software/stack/loadLSST.bash
 conda env export | tee sciplat-conda-stack.yaml
-uv pip tree | tee "sciplat-conda-stack-tree"
+# If conda-tree is installed, use it to generate a tree view of dependencies.
+# If not, clean up output from the failed command
+if ! (which conda tree --full > sciplat-conda-stack-tree); then
+    rm -f sciplat-conda-stack-tree
+fi

--- a/scripts/helper-functions.sh
+++ b/scripts/helper-functions.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+RELEASE_BRANCH="main"  # main sciplat-lab branch
+## FIXME: take this out after we are past DP2 and have cleaned up everything.
+MAGIC_BLESSED_TAG="tickets-DM-55555"
+
 input_tag_to_version() {
     if [ "${tag}" = "" ]; then
         echo "tag cannot be empty" >&2
@@ -28,44 +32,94 @@ calculate_tags() {
     fi
 
     branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true )
-    if [ -n "${OVERRIDE_BRANCH}" ]; then
-        branch="${OVERRIDE_BRANCH}"
-    fi
     if [ -z "${branch}" ]; then
         echo "cannot determine git branch" >&2
         branch="NOGIT"
     fi
 
-    release_branch="main"
-
     version=$(input_tag_to_version)
     input_tag=$(echo "${input}" | cut -d ':' -f 2)
-    tag_type=$(echo ${version} | cut -c 1)    
-    if [ "${branch}" != "${release_branch}" ] || \
-           ( [ "${input_tag}" != "latest" ] && [ "${tag_type}" != "r" ] ); then
-
-        # This is correct: we do allow building *releases* from different
-        # input tags, because they have a unique build number and thus
-        # will not overwrite earlier versions, and it may be necessary to
-        # rebuild a release with the jupyterlab-base version current at the
-        # original build time.
-
-        discriminator="${branch}"
-        if [ "${input_tag}" != "latest" ]; then
-            discriminator="${input_tag}"
-        fi
-        if [ -z "${supplementary}" ]; then
-            supplementary=$( echo ${discriminator} | tr -c -d \[A-z\]\[0-9\] )
-        fi
-    fi
-    if [ -n "${supplementary}" ] && \
-           [ "${OVERRIDE_BRANCH}" != "${release_branch}" ]; then
-        version="exp_${version}_${supplementary}"
-    fi
-
-    # Recalculate tag, because we might have just forced an experimental.
     tag_type=$(echo ${version} | cut -c 1)
+    ## FIXME: remove MAGIC_BLESSED_TAG post-DP2 and cleanup.
+
+    # Determine whether we should force an experimental build.
+    # We want to do that so that we cannot, by omitting the
+    # "supplementary" parameter, accidentally overwrite an official daily
+    # or weekly image that we have built either from a branch of sciplat-lab
+    # or from a base image that doesn't have the "latest" tag.
+    # Releases and release candidates are protected from
+    # overwrite because a unique build number is embedded into their tag.
+
+    # If the branch of sciplat-lab is neither the release branch nor
+    # a specified override branch (set externally by the caller in
+    # ${OVERRIDE_BRANCH}), the build must be experimental, and the branch
+    # forcing it is in ${exp_branch}.
     
+    exp_branch=""
+    if [ "${branch}" != "${RELEASE_BRANCH}" ] && \
+       [ "${branch}" != "${OVERRIDE_BRANCH}" ]; then
+        exp_branch="${branch}"
+    fi
+    # If the tag is of a release type, the build doesn't have to be an
+    # experimental.  That's for the case where we have to rebuild an older
+    # image with the jupyterlab-base image that was current at the time of
+    # the first build.
+    #
+    # That's OK because all release types (which currently includes release
+    # candidates) embed the unique build number, so there is no danger of
+    # overwriting.  However, if it is not a release type, then we will force
+    # an experimental build if the tag is not "latest".
+    #
+    # FIXME: We also will allow a non-experimental build if the tag matches
+    # ${MAGIC_BLESSED_TAG}.  This is a hack to let us get images out around
+    # DP2, and will be removed afterwards as part of our post-release cleanup.
+    
+    exp_tag=""
+    if [ "${tag_type}" != "r" ] && \
+       { [ "${input_tag}" != "latest" ] && \
+             [ "${input_tag}" != "${MAGIC_BLESSED_TAG}" ] }; then
+        exp_tag="${input_tag}"
+    fi
+
+    # Put it all together.  If supplementary is already set, we don't need
+    # to force anything to experimental, because the user-set supplementary
+    # tag trumps everything and we will simply use it.  Nothing with
+    # supplementary explicitly set can ever be a non-experimental version.
+
+    # If either the branch or input tag are set to something that should force
+    # an experimental build, though, then we need to go through the logic
+    # to derive a supplementary tag and force an experimental build.
+
+    if [ -z "${supplementary}" ]; then
+        if [ -n "${exp_branch}" ] || [ -n "${exp_tag}" ]; then
+	    # Prefer tag over branch for setting the supplementary tag.
+            discriminator=""
+            if [ -n "${exp_tag}" ]; then
+                discriminator="${exp_tag}"
+            else
+                discriminator="${exp_branch}"
+            fi
+
+            supplementary=$( echo ${discriminator} | tr -c -d \[A-z\]\[0-9\] )
+
+            if [ -z "${supplementary}" ]; then
+                # This shouldn't happen.  If we can get here it's a bug I
+                # didn't spot in the logic.
+                supplementary="experimental"
+            fi
+        fi
+    fi
+    if [ -n "${supplementary}" ]; then
+        version="exp_${version}_${supplementary}"
+        supplementary=""
+        # Clear supplementary for help with testing, where we might run this
+        # multiple times in the same shell; it will never matter in real
+        # life.
+    fi
+
+    # Recalculate tag type, because we might have just forced an experimental.
+    tag_type=$(echo ${version} | cut -c 1)
+
     # Experimentals do not get tagged as latest anything.  Dailies,
     #  weeklies, and releases get tagged as latest_<category>.  The
     #  "latest" tag for the lab container should always point to the

--- a/scripts/helper-functions.sh
+++ b/scripts/helper-functions.sh
@@ -75,10 +75,11 @@ calculate_tags() {
     # DP2, and will be removed afterwards as part of our post-release cleanup.
     
     exp_tag=""
-    if [ "${tag_type}" != "r" ] && \
-       { [ "${input_tag}" != "latest" ] && \
-             [ "${input_tag}" != "${MAGIC_BLESSED_TAG}" ] }; then
-        exp_tag="${input_tag}"
+    if [ "${tag_type}" != "r" ]; then
+        if [ "${input_tag}" != "latest" ] && \
+               [ "${input_tag}" != "${MAGIC_BLESSED_TAG}" ]; then
+            exp_tag="${input_tag}"
+        fi
     fi
 
     # Put it all together.  If supplementary is already set, we don't need
@@ -92,7 +93,7 @@ calculate_tags() {
 
     if [ -z "${supplementary}" ]; then
         if [ -n "${exp_branch}" ] || [ -n "${exp_tag}" ]; then
-	    # Prefer tag over branch for setting the supplementary tag.
+            # Prefer tag over branch for setting the supplementary tag.
             discriminator=""
             if [ -n "${exp_tag}" ]; then
                 discriminator="${exp_tag}"

--- a/scripts/install-rsp-user
+++ b/scripts/install-rsp-user
@@ -113,9 +113,6 @@ fi
 echo "Doing separate installation of lsst-rsp"
 conda install -y --no-update-deps lsst-rsp
 
-# Install conda-tree for conda dependency graph.
-conda install -y --no-update-deps conda-tree
-
 # Clean caches
 conda clean -a -y -f
 uv cache clean

--- a/scripts/install-rsp-user
+++ b/scripts/install-rsp-user
@@ -113,6 +113,9 @@ fi
 echo "Doing separate installation of lsst-rsp"
 conda install -y --no-update-deps lsst-rsp
 
+# Install conda-tree for conda dependency graph.
+conda install -y --no-update-deps conda-tree
+
 # Clean caches
 conda clean -a -y -f
 uv cache clean


### PR DESCRIPTION
Having the tree view, to know what package brought in what, is a very useful debugging aid.

RFC-1195 captures adding conda tree to the environment, and if it is present, we will use it in the stack environment.  For the base system environment and for the JupyterLab UI environment we can just use `uv pip tree`.